### PR TITLE
Add some tables

### DIFF
--- a/facing.tex
+++ b/facing.tex
@@ -21,11 +21,13 @@ After finishing all movement, all combat units must be \textit{faced} (oriented)
 
 \subsubsection[Flank or Rear]{} Friendly units attacking the flank or rear hexsides of an enemy unit receive a bonus to their combat rating (either fire or melee), as given.
 
-\begin{tabular}{ lcc }
+\begin{tabular}{ |lcc| }
+  \hline & & \\[-2.0ex]
   & \textbf{Flank} & \textbf{Rear} \\
-  \hline \\ [-2.0ex]
+  \hline & &\\ [-2.0ex]
   Fire & +1 & +1 \\
   Melee & +1 & +2 \\
+  \hline
 \end{tabular}
 
 Thus, a Breton foot unit in Advance to Combat order meleeing a Saxon fyrd unit through the fyrd's rear hexside would have a melee rating of “6” rather than its printed rating of “4".

--- a/leaders.tex
+++ b/leaders.tex
@@ -44,9 +44,11 @@ Leaders aid in melee combat and rally troops. Saxon leaders determine the dispos
 
 \subsection{The Leader Casualty Table}
 
-\begin{tabular}{ ccl }
+\begin{center}
+\begin{tabular}{ |ccl| }
+  \hline & &\\ [-2.0ex]
   \textbf{Fire} & \textbf{Melee} & \textbf{Result} \\
-  \hline \\ [-2.0ex]
+  \hline & &\\ [-2.0ex]
   2,12 & 2,12 & Leader Killed \\
   3,11 & 3 & Leader Wounded\textsuperscript{1} \\
   -- & 11,4,10 & Leader Wounded\textsuperscript{2} \\
@@ -54,6 +56,7 @@ Leaders aid in melee combat and rally troops. Saxon leaders determine the dispos
   4-10 & 6,7,8 & Nothing Happens \\
   \hline
 \end{tabular}
+\end{center}
 
 \textsuperscript{1:} Leader remains in current status. Both his command radius and rally radius are reduced by 1 for the rest of the game.
 

--- a/leaders.tex
+++ b/leaders.tex
@@ -44,7 +44,6 @@ Leaders aid in melee combat and rally troops. Saxon leaders determine the dispos
 
 \subsection{The Leader Casualty Table}
 
-\begin{center}
 \begin{tabular}{ |ccl| }
   \hline & &\\ [-2.0ex]
   \textbf{Fire} & \textbf{Melee} & \textbf{Result} \\
@@ -56,7 +55,6 @@ Leaders aid in melee combat and rally troops. Saxon leaders determine the dispos
   4-10 & 6,7,8 & Nothing Happens \\
   \hline
 \end{tabular}
-\end{center}
 
 \textsuperscript{1:} Leader remains in current status. Both his command radius and rally radius are reduced by 1 for the rest of the game.
 

--- a/leaders.tex
+++ b/leaders.tex
@@ -42,4 +42,21 @@ Leaders aid in melee combat and rally troops. Saxon leaders determine the dispos
 
 \subsubsection[William and Harold]{} If either William or Harold is wounded or killed, all friendly units within command radius must make an immediate morale check.
 
-\subsection{The Leader Casualty Table} \textit{(see map)}
+\subsection{The Leader Casualty Table}
+
+\begin{tabular}{ ccl }
+  \textbf{Fire} & \textbf{Melee} & \textbf{Result} \\
+  \hline \\ [-2.0ex]
+  2,12 & 2,12 & Leader Killed \\
+  3,11 & 3 & Leader Wounded\textsuperscript{1} \\
+  -- & 11,4,10 & Leader Wounded\textsuperscript{2} \\
+  -- & 5,9 & Leader Shaken\textsuperscript{3} \\
+  4-10 & 6,7,8 & Nothing Happens \\
+  \hline
+\end{tabular}
+
+\textsuperscript{1:} Leader remains in current status. Both his command radius and rally radius are reduced by 1 for the rest of the game.
+
+\textsuperscript{2:} Leader is flipped to his ineffective side for the remainder of the Assault Period.
+
+\textsuperscript{3:} Leader is unhorsed/shaken. Flip the leader to his ineffective side for the remainder of this Battle Phase and all of the next. If already shaken, roll 1d6: 1-3 killed, 4-6 nothing happens.

--- a/melee_results.tex
+++ b/melee_results.tex
@@ -72,7 +72,21 @@ A unit can attempt to rally only once per segment. If there is a leader within r
 
 \subsubsection[Routed Units]{} Routed units are automatically rallied if they are within the rally range of a friendly leader in the rally segment. \textit{No die roll is necessary}. If a routed unit is not rallied, it retreats two hexes, following the retreat pattern described in 9.23.
 
-\subsubsection{The Rally Table} \textit{(see map)}
+\subsection{The Rally Check Table}
+
+\begin{center}
+\begin{tabular}{ cc }
+    \textbf{Morale Rating} & {\textbf{Die Roll}} \\
+    \hline \\ [-2.0ex]
+    A & 1-5 \\
+    B & 1-4 \\
+    C & 1-3 \\
+    D & 1-2 \\
+    E & 1 \\
+    \hline
+\end{tabular}
+\end{center}
+A successful rally check removes a disruption marker. Rout markers are automatically removed if the routed unit is within the rally range of a friendly leader in the Rally phase.
 
 \subsection{Morale Checks}
 
@@ -94,4 +108,19 @@ In all the above cases, any rout results are treated as disruptions.
 
 \subsubsection[No Limits]{} There is no limit to the number of times a given unit can be forced to check morale in a segment; a check is made whenever required by the game situation.
 
-\subsubsection{} \textbf{The Morale Check Table} \textit{see map}
+\subsection{Morale Check Table}
+
+\begin{center}
+\begin{tabular}{ cccccc }
+    \multicolumn{6}{c}{ \textbf{Morale Level}} \\
+    Die Roll & A & B & C & D & E \\
+    \hline \\ [-2.0ex]
+    1 & -- & -- & -- & -- & -- \\
+    2 & -- & -- & -- & D & D \\
+    3 & -- & -- & -- & D & R \\
+    4 & -- & D & D & R & R \\
+    5 & D & D & R & R & R \\
+    6 & D & R & R & R & R \\
+    \hline
+\end{tabular}
+\end{center}

--- a/melee_results.tex
+++ b/melee_results.tex
@@ -1,7 +1,24 @@
 \section{MELEE RESULTS}
 \hfill
 
-\subsection{Melee Results Table} (see map)
+\subsection{Melee Results Table}
+
+{\def\arraystretch{1.4}
+\resizebox{\columnwidth}{!}{
+\begin{tabular}{ |cccccccccccc| }
+  \multicolumn{12}{c}{ \textbf{Melee Differential} } \\
+  \hline& & & & & & & & & & & \\[-2.5ex]
+  Die Roll & -6 & -5 & -4 & -3 & -2 & -1 & 0 & +1 & +2/+3 & +4/+5 & +6 \\
+  \hline& & & & & & & & & & & \\[-2.5ex]
+  1 & 1/- & 1/- & 1/- & 1/- & 1/- & 1/D* & 1/D* & M/- & D*/- & 1/1 & D*/1 \\
+  2 & 1/- & 1/- & 1/- & 1/- & 1/D* & M/- & M/- & D*/- & 1/1 & D*/1 & -/M \\
+  3 & 1/- & 1/- & 1/- & 1/D* & M/- & D*/- & 1/1 & D*/1 & -/M & -/1 & -/1\\
+  4 & 1/- & 1/- & 1/D* & M/1 & D*/- & 1/1 & 1/1 & D*/1 & -/M & -/1 & -/1\\
+  5 & 1/- & 1/D* & M/- & D*/- & 1/1 & 1/1 & D*/1 & -/M & -/1 & -/1 & -/1M\\
+  6 & 1/D* & M/- & D*/- & 1/1 & 1/1 & D*/1 & -/M & -/1 & -/1 & -/1M & -/1M\\
+  \hline
+\end{tabular}
+}}
 
 \subsection{Explanation of Melee Results}
 

--- a/melee_results.tex
+++ b/melee_results.tex
@@ -92,9 +92,10 @@ A unit can attempt to rally only once per segment. If there is a leader within r
 \subsection{The Rally Check Table}
 
 \begin{center}
-\begin{tabular}{ cc }
+\begin{tabular}{ |cc| }
+    \hline & \\[-2.0ex]
     \textbf{Morale Rating} & {\textbf{Die Roll}} \\
-    \hline \\ [-2.0ex]
+    \hline & \\ [-2.0ex]
     A & 1-5 \\
     B & 1-4 \\
     C & 1-3 \\
@@ -128,8 +129,9 @@ In all the above cases, any rout results are treated as disruptions.
 \subsection{Morale Check Table}
 
 \begin{center}
-\begin{tabular}{ cccccc }
+\begin{tabular}{ |cccccc| }
     \multicolumn{6}{c}{ \textbf{Morale Level}} \\
+    \hline & & & & & \\[-2.0ex]
     Die Roll & A & B & C & D & E \\
     \hline \\ [-2.0ex]
     1 & -- & -- & -- & -- & -- \\

--- a/melee_results.tex
+++ b/melee_results.tex
@@ -91,7 +91,6 @@ A unit can attempt to rally only once per segment. If there is a leader within r
 
 \subsection{The Rally Check Table}
 
-\begin{center}
 \begin{tabular}{ |cc| }
     \hline & \\[-2.0ex]
     \textbf{Morale Rating} & {\textbf{Die Roll}} \\
@@ -103,7 +102,7 @@ A unit can attempt to rally only once per segment. If there is a leader within r
     E & 1 \\
     \hline
 \end{tabular}
-\end{center}
+
 A successful rally check removes a disruption marker. Rout markers are automatically removed if the routed unit is within the rally range of a friendly leader in the Rally phase.
 
 \subsection{Morale Checks}
@@ -128,7 +127,6 @@ In all the above cases, any rout results are treated as disruptions.
 
 \subsection{Morale Check Table}
 
-\begin{center}
 \begin{tabular}{ |cccccc| }
     \multicolumn{6}{c}{ \textbf{Morale Level}} \\
     \hline & & & & & \\[-2.0ex]
@@ -142,4 +140,3 @@ In all the above cases, any rout results are treated as disruptions.
     6 & D & R & R & R & R \\
     \hline
 \end{tabular}
-\end{center}

--- a/missile_fire_combat.tex
+++ b/missile_fire_combat.tex
@@ -92,7 +92,8 @@ Because of the lack of Saxon bowmen and Norman spearmen, the opposing sides coul
 
 {\def\arraystretch{1.2}
   \begin{tabular}{ |lcccc| }
-    \multicolumn{5}{c}{ \textbf{Range in Hexes}} \\
+    \hline
+    & & \multicolumn{3}{c|}{ \textbf{Range}} \\
     \hline
     Weapon & Max. Range & 3 & 2 & 1* \\
     \hline

--- a/missile_fire_combat.tex
+++ b/missile_fire_combat.tex
@@ -77,12 +77,14 @@ Because of the lack of Saxon bowmen and Norman spearmen, the opposing sides coul
 
 \subsection{Missile Supply Table}
 
-\begin{tabular}{ lcc }
-  \textbf{Assault Period} & \multicolumn{2}{c}{\textbf{Fire Segments Allowed}} \\
-  & Norman Bowmen & Saxon Jav/Sps \\
+\begin{tabular}{ |l|cc| }
+  \hline & & \\[-2.0ex]
+  \textbf{Assault} & \multicolumn{2}{c|}{\textbf{Fire Segments Allowed}} \\
+  \textbf{Period} & Norman Bowmen & Saxon Jav/Sps \\
   \hline & &\\ [-2.0ex]
   First & 6 & 4 \\
-  Second & 3 & 2
+  Second & 3 & 2 \\
+  \hline
 \end{tabular}
 
 \subsection{The Missile Combat Tables}

--- a/missile_fire_combat.tex
+++ b/missile_fire_combat.tex
@@ -88,15 +88,18 @@ Because of the lack of Saxon bowmen and Norman spearmen, the opposing sides coul
 \subsection{The Missile Combat Tables}
 \subsection{Missile Fire Matrix}
 
-\begin{tabular}{ lcccc }
-  \multicolumn{5}{c}{ \textbf{Range in Hexes}} \\
-  Weapon & Max. Range & 3 & 2 & 1* \\
-  \hline \\ [-2.0ex]
-  Bow & 3 hexes & 3 & 4 & 5 \\
-  Javelin & 2 hexes & - & 2 & 3 \\
-  Sling & 3 hexes & 1 & 1 & 2 \\
-  \hline
-\end{tabular}
+{\def\arraystretch{1.2}
+  \begin{tabular}{ |lcccc| }
+    \multicolumn{5}{c}{ \textbf{Range in Hexes}} \\
+    \hline
+    Weapon & Max. Range & 3 & 2 & 1* \\
+    \hline
+    Bow & 3 hexes & 3 & 4 & 5 \\
+    Javelin & 2 hexes & - & 2 & 3 \\
+    Sling & 3 hexes & 1 & 1 & 2 \\
+    \hline
+  \end{tabular}
+}
 \par
 The resultant number is the missile fire strength of the unit.
 
@@ -104,17 +107,21 @@ The resultant number is the missile fire strength of the unit.
 
 \subsection{Missile Combat Results Table}
 
-\resizebox{\columnwidth}{!}{\begin{tabular}{ ccccccccccc }
+{\def\arraystretch{1.2}
+\resizebox{\columnwidth}{!}{\begin{tabular}{ |ccccccccccc| }
   \multicolumn{11}{c}{ \textbf{Fire Ratio} } \\
+  \hline& & & & & & & & & &\\[-2.5ex]
   Die Roll & 1-4 & 1-3 & 1-2 & 1-1.5 & 1-1 & 1.5-1 & 2-1 & 3-1 & 4-1 & 5-1 \\
-  \hline \\ [-1.5ex]
+  \hline
   1 & -- & -- & -- & -- & -- & M & M & M & D & D \\
   2 & -- & -- & -- & -- & M & M & M & D & D & D \\
   3 & -- & -- & -- & M & M & M & D & D & D & 1 \\
   4 & -- & -- & M & M & M & D & D & D & 1 & 1 \\
   5 & -- & M & M & M & D & D & D & 1 & 1 & 1 \\
-  6 & M & M & M & D & D & D & 1 & 1 & 1 & 1
+  6 & M & M & M & D & D & D & 1 & 1 & 1 & 1 \\
+  \hline
 \end{tabular}}
+}
 \par
 Attacks at less than 1-4 are ineffective. Attacks at greater than 5-1 odds are treated as 5-1.
 

--- a/missile_fire_combat.tex
+++ b/missile_fire_combat.tex
@@ -79,9 +79,8 @@ Because of the lack of Saxon bowmen and Norman spearmen, the opposing sides coul
 
 \begin{tabular}{ lcc }
   \textbf{Assault Period} & \multicolumn{2}{ c } {\textbf{Fire Segments Allowed}} \\
-  & Norman & Saxon \\
-  & Bowmen & Jav/Sps \\
-  \hline
+  & Norman Bowmen & Saxon Jav/Sps \\
+  \hline \\ [-2.0ex]
   First & 6 & 4 \\
   Second & 3 & 2
 \end{tabular}

--- a/missile_fire_combat.tex
+++ b/missile_fire_combat.tex
@@ -87,5 +87,36 @@ Because of the lack of Saxon bowmen and Norman spearmen, the opposing sides coul
 \end{tabular}
 
 \subsection{The Missile Combat Tables}
-\subsection{Missile Fire Matrix} \textit{(see map)}
-\subsection{Missile Combat Results Table} \textit{(see map)}
+\subsection{Missile Fire Matrix}
+
+\begin{tabular}{ lcccc }
+  \multicolumn{5}{c}{ \textbf{Range in Hexes}} \\
+  Weapon & Max. Range & 3 & 2 & 1* \\
+  \hline \\ [-2.0ex]
+  Bow & 3 hexes & 3 & 4 & 5 \\
+  Javelin & 2 hexes & - & 2 & 3 \\
+  Sling & 3 hexes & 1 & 1 & 2 \\
+  \hline
+\end{tabular}
+\par
+The resultant number is the missile fire strength of the unit.
+
+* Bowmen cannot enter ZOC. Bowmen starting a movement segment in an enemy ZOC must move out if possible.
+
+\subsection{Missile Combat Results Table}
+
+\resizebox{\columnwidth}{!}{\begin{tabular}{ ccccccccccc }
+  \multicolumn{11}{c}{ \textbf{Fire Ratio} } \\
+  Die Roll & 1-4 & 1-3 & 1-2 & 1-1.5 & 1-1 & 1.5-1 & 2-1 & 3-1 & 4-1 & 5-1 \\
+  \hline \\ [-1.5ex]
+  1 & -- & -- & -- & -- & -- & M & M & M & D & D \\
+  2 & -- & -- & -- & -- & M & M & M & D & D & D \\
+  3 & -- & -- & -- & M & M & M & D & D & D & 1 \\
+  4 & -- & -- & M & M & M & D & D & D & 1 & 1 \\
+  5 & -- & M & M & M & D & D & D & 1 & 1 & 1 \\
+  6 & M & M & M & D & D & D & 1 & 1 & 1 & 1
+\end{tabular}}
+\par
+Attacks at less than 1-4 are ineffective. Attacks at greater than 5-1 odds are treated as 5-1.
+
+Explanation of results: "--" = No effect; M = Unit must undergo a morale check; D = Unit is disrupted; 1 = Unit loses 1 step and any leader present must be checked for possible loss.

--- a/missile_fire_combat.tex
+++ b/missile_fire_combat.tex
@@ -78,9 +78,9 @@ Because of the lack of Saxon bowmen and Norman spearmen, the opposing sides coul
 \subsection{Missile Supply Table}
 
 \begin{tabular}{ lcc }
-  \textbf{Assault Period} & \multicolumn{2}{ c } {\textbf{Fire Segments Allowed}} \\
+  \textbf{Assault Period} & \multicolumn{2}{c}{\textbf{Fire Segments Allowed}} \\
   & Norman Bowmen & Saxon Jav/Sps \\
-  \hline \\ [-2.0ex]
+  \hline & &\\ [-2.0ex]
   First & 6 & 4 \\
   Second & 3 & 2
 \end{tabular}

--- a/victory_conditions.tex
+++ b/victory_conditions.tex
@@ -18,20 +18,18 @@ However, if the Normans have lost more casualty points than the Saxons, the game
 
 Each time a unit is eliminated, its side accumulates casualty points. These are totalled at the end of the game, and can affect possible Norman victories (12.1). Points are awarded on the given table.
 
-\begin{center}
-  \begin{tabular}{ |lc| }
-    \hline &\\[-2.0ex]
-    \textbf{Unit} & \textbf{Casualty Points} \\
-    \hline &\\[-2.0ex]
-    "A" Morale unit & 15 \\
-    "B" Morale unit & 7 \\
-    "C" Morale unit & 3 \\
-    "D" Morale unit & 2 \\
-    "E" Morale unit & 1 \\
-    William & 50 \\
-    Harold & 25 \\
-    Odo & 10 \\
-    Other Leader & 5 \\
-    \hline
-  \end{tabular}
-\end{center}
+\begin{tabular}{ |lc| }
+  \hline &\\[-2.0ex]
+  \textbf{Unit} & \textbf{Casualty Points} \\
+  \hline &\\[-2.0ex]
+  "A" Morale unit & 15 \\
+  "B" Morale unit & 7 \\
+  "C" Morale unit & 3 \\
+  "D" Morale unit & 2 \\
+  "E" Morale unit & 1 \\
+  William & 50 \\
+  Harold & 25 \\
+  Odo & 10 \\
+  Other Leader & 5 \\
+  \hline
+\end{tabular}

--- a/victory_conditions.tex
+++ b/victory_conditions.tex
@@ -19,9 +19,10 @@ However, if the Normans have lost more casualty points than the Saxons, the game
 Each time a unit is eliminated, its side accumulates casualty points. These are totalled at the end of the game, and can affect possible Norman victories (12.1). Points are awarded on the given table.
 
 \begin{center}
-  \begin{tabular}{ l cc }
+  \begin{tabular}{ |lc| }
+    \hline &\\[-2.0ex]
     \textbf{Unit} & \textbf{Casualty Points} \\
-    \hline \\ [-2.0ex]
+    \hline &\\[-2.0ex]
     "A" Morale unit & 15 \\
     "B" Morale unit & 7 \\
     "C" Morale unit & 3 \\
@@ -30,6 +31,7 @@ Each time a unit is eliminated, its side accumulates casualty points. These are 
     William & 50 \\
     Harold & 25 \\
     Odo & 10 \\
-    Other Leader & 5
+    Other Leader & 5 \\
+    \hline
   \end{tabular}
 \end{center}


### PR DESCRIPTION
This adds a fair number of tables directly into the rules.

These aren't in the published rules, but I think it had more to do with the limited format/page count of a magazine game rather than an overt decision to exclude them for any particular aesthetic reason. Since I have no such limitation, I've decided to integrate them.